### PR TITLE
Build image browser to display and filter OME-ZARR wells

### DIFF
--- a/src/napari_ome_zarr_navigator/_sample_data.py
+++ b/src/napari_ome_zarr_navigator/_sample_data.py
@@ -8,6 +8,7 @@ import urllib
 import hashlib
 import wget
 import shutil
+import logging
 
 from napari.types import LayerDataTuple
 
@@ -15,6 +16,8 @@ from ome_zarr.io import parse_url
 from ome_zarr.reader import Reader, Node
 
 from napari_ome_zarr_navigator import _TEST_DATA_DIR
+
+logging.getLogger("ome_zarr").setLevel(logging.WARN)
 
 
 def load_ome_zarr_from_zenodo(doi: str, zarr_url: Union[str, Path]):

--- a/src/napari_ome_zarr_navigator/_sample_data.py
+++ b/src/napari_ome_zarr_navigator/_sample_data.py
@@ -88,7 +88,7 @@ def verify_checksum(filename: Union[str, Path], algorithm, original_checksum):
 
 
 def hiPSC_zarr() -> list[LayerDataTuple]:
-    doi = "10.5281_zenodo.10424292"
+    doi = "10.5281_zenodo.11262587"
     zarr_url = "20200812-CardiomyocyteDifferentiation14-Cycle1_mip.zarr"
     return load_zarr(doi, zarr_url)
 

--- a/src/napari_ome_zarr_navigator/img_browser.py
+++ b/src/napari_ome_zarr_navigator/img_browser.py
@@ -34,22 +34,8 @@ class ImgBrowser(Container):
             label="OME-ZARR URL", mode="d", filter="*.zarr"
         )
         self.filters = []
-        self.drug = ComboBox(
-            label="Drug",
-        )
-        self.concentration = ComboBox(
-            label="Conc. (nM)",
-        )
-        self.display_drugs = Select(
-            label="content", enabled=True, allow_multiple=False
-        )
-        self.select_well = PushButton(text="Go to well", enabled=False)
-        self.new_layers = CheckBox(label="Add Image/Labels as new layer(s)")
-        self.drug_layout = pd.DataFrame(
-            {"row": [], "col": [], "drug": [], "concentration": [], "unit": []}
-        )
-
         self.well = Select(label="Wells", enabled=True, allow_multiple=False)
+        self.select_well = PushButton(text="Go to well", enabled=False)
 
         super().__init__(
             widgets=[self.zarr_dir, self.well, self.select_well],

--- a/src/napari_ome_zarr_navigator/run_img_browser.py
+++ b/src/napari_ome_zarr_navigator/run_img_browser.py
@@ -6,14 +6,10 @@ from napari_ome_zarr_navigator import _TEST_DATA_DIR
 
 
 def main():
-    zarr_url = "20200812-CardiomyocyteDifferentiation14-Cycle1_mip.zarr/B/03/0"
     viewer = napari.Viewer()
-    zarr_url = "20200812-CardiomyocyteDifferentiation14-Cycle1_mip.zarr/B/03/0"
     roi_loader_widget = ImgBrowser(
         viewer,
-        # zarr_url=_TEST_DATA_DIR.joinpath("10.5281_zenodo.10424292", zarr_url),
     )
-
     viewer.window.add_dock_widget(roi_loader_widget, name="OME-ZARR navigator")
     viewer.show(block=True)
 


### PR DESCRIPTION
- The image browser receives an OME-ZARR and displays the available wells in a magicgui Select widget. 
- If a condition table is present, a Container with ComboBoxes for each column (e.g. drug, concentration) in the condition table is loaded. This allows to filter the well list with an AND operator.
- Clicking on *Go to well* zooms in and draws a rectangle around the selected well. This should be the entry point to the ROI loader.