### PR TITLE
Update to ngio 0.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     napari-ome-zarr
     ome-zarr
     wget
-    ngio>=0.2.4, < 0.3
+    ngio>=0.4.0
     numcodecs!=0.14.0,!=0.14.1,!=0.16 # avoids zarr issue
 
 python_requires = >=3.11

--- a/src/napari_ome_zarr_navigator/roi_loader.py
+++ b/src/napari_ome_zarr_navigator/roi_loader.py
@@ -287,7 +287,7 @@ class ROILoader(Container):
 
     def update_available_image_attrs(self, new_zarr_img):
         if new_zarr_img:
-            channels = self.ome_zarr_container.image_meta.channel_labels
+            channels = self.ome_zarr_container.channel_labels
             levels = self.ome_zarr_container.levels_paths
             try:
                 labels = self.ome_zarr_container.list_labels()


### PR DESCRIPTION
Looks like the update to ngio 0.4 is simple (just a few minor API changes on metadata access & ROI table handling). In my tests & the CI, this no works fine & is backwards compatible.

Only downside I've noticed is that the default ordering of ROI tables is different, sometimes leading to masking ROI tables with very many entries being the default => the initialisation of the widget becomes slower and a spinner can show up.

Besides potentially optimising the order in which ROI tables are shown (e.g. show masking ROI tables last?), everything looks smooth.

I'll merge this and make the first 0.4 release. This then also unblocks doing more with condition tables & plate-level condition tables